### PR TITLE
Add test target for iojs v1, v2, v3, nodejs v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - 'iojs-1'
   - 'iojs-2'
   - 'iojs-3'
+  - '4'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - '0.10'
   - '0.12'
+  - 'iojs-1'
+  - 'iojs-2'
+  - 'iojs-3'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ environment:
   matrix:
     - nodejs_version: 0.10
     - nodejs_version: 0.12
+    - nodejs_version: 1
+    - nodejs_version: 2
+    - nodejs_version: 3
 
 # get the latest stable version of Node 0.STABLE.latest
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
     - nodejs_version: 1
     - nodejs_version: 2
     - nodejs_version: 3
+    - nodejs_version: 4
 
 # get the latest stable version of Node 0.STABLE.latest
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
 
 # get the latest stable version of Node 0.STABLE.latest
 install:
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - ps: Install-Product node $env:nodejs_version
   - npm install
 
 build: off


### PR DESCRIPTION
- Add test target for iojs v1, v2, v3
- Add test target nodejs v4
- Use Install-Product node instead of Update-NodeJsInstallation (appveyor)
  - http://help.appveyor.com/discussions/suggestions/810-nodejs-400-is-out
    `Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)`
    command doesn't work with Node 4 yet.
  - https://github.com/nodejs/nan/issues/444#issuecomment-138896865
